### PR TITLE
Remove full path to `pidof` in app-admin/syslog-ng rule

### DIFF
--- a/etc/app-admin/syslog-ng
+++ b/etc/app-admin/syslog-ng
@@ -1,6 +1,6 @@
 echo /var/run/syslog-ng.pid
 echo /var/lib/syslog-ng/syslog-ng.persist
 #
-SYSLOGNGPID=`/usr/bin/pidof syslog-ng | cut -f1 -d' '`
+SYSLOGNGPID=`pidof syslog-ng | cut -f1 -d' '`
 lsof -Fn +D /var/log/ -a -p ${SYSLOGNGPID} | sed 's/^n//;tn;d;:n'
 


### PR DESCRIPTION
/etc/findcruft/app-admin/syslog-ng rule calls `pidof` by its full path `/usr/bin/pidof`, but this executable is not actually located there, so it fails:

```
/etc/findcruft/app-admin/syslog-ng: line 4: /usr/bin/pidof: No such file or directory
```

This commit just calls `pidof` without its full path so letting system locate it in `$PATH`